### PR TITLE
ui/server: PHP 8.4 ZTS + RoadRunner + php-parallax dogfood

### DIFF
--- a/.github/workflows/ui-server.yml
+++ b/.github/workflows/ui-server.yml
@@ -18,6 +18,12 @@ defaults:
   run:
     working-directory: ui/server
 
+env:
+  # The php-parallax extension is required at runtime but lives only inside
+  # the project's ZTS Docker image; CI runs on shivammathur/setup-php which
+  # is NTS, so composer needs to know not to fail the platform check.
+  COMPOSER_FLAGS: '--prefer-dist --no-progress --no-interaction --ignore-platform-req=ext-parallax'
+
 jobs:
   composer:
     name: composer resolve
@@ -26,16 +32,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: bcmath, gd, iconv, intl, mbstring, opcache, pcntl, pdo_mysql, sockets, xsl, zip
-      - name: resolve deps (lockfile is regenerated until first stable run)
+      - name: resolve deps
         run: |
           if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress --no-interaction --ansi
+            composer install $COMPOSER_FLAGS --ansi
           else
-            composer update --prefer-dist --no-progress --no-interaction --no-audit --ansi --no-scripts
+            composer update $COMPOSER_FLAGS --no-scripts --ansi
           fi
 
   cs-fixer:
@@ -46,18 +52,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: bcmath, gd, iconv, intl, mbstring, opcache, pcntl, pdo_mysql, sockets, xsl, zip
-      - run: |
-          if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress --no-interaction
-          else
-            composer update --prefer-dist --no-progress --no-interaction --no-scripts --no-audit
-          fi
+      - run: composer install $COMPOSER_FLAGS
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --allow-risky=yes
-        continue-on-error: true
 
   phpstan:
     name: phpstan
@@ -67,18 +67,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: bcmath, gd, iconv, intl, mbstring, opcache, pcntl, pdo_mysql, sockets, xsl, zip
-      - run: |
-          if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress --no-interaction
-          else
-            composer update --prefer-dist --no-progress --no-interaction --no-scripts --no-audit
-          fi
+      - run: composer install $COMPOSER_FLAGS
       - run: vendor/bin/phpstan analyse --memory-limit=1G --no-progress
-        continue-on-error: true
 
   rector:
     name: rector --dry-run
@@ -88,21 +82,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: bcmath, gd, iconv, intl, mbstring, opcache, pcntl, pdo_mysql, sockets, xsl, zip
-      - run: |
-          if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress --no-interaction
-          else
-            composer update --prefer-dist --no-progress --no-interaction --no-scripts --no-audit
-          fi
+      - run: composer install $COMPOSER_FLAGS
       - run: vendor/bin/rector process --dry-run --no-progress-bar
-        continue-on-error: true
 
   phpunit:
-    name: phpunit
+    name: phpunit (functional + unit, MySQL 8.4)
     runs-on: ubuntu-latest
     needs: composer
     services:
@@ -121,18 +109,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: bcmath, gd, iconv, intl, mbstring, opcache, pcntl, pdo_mysql, sockets, xsl, zip
-      - run: |
-          if [ -f composer.lock ]; then
-            composer install --prefer-dist --no-progress --no-interaction
-          else
-            composer update --prefer-dist --no-progress --no-interaction --no-scripts --no-audit
-          fi
+      - run: composer install $COMPOSER_FLAGS
       - env:
           APP_ENV: test
           DATABASE_URL: mysql://root:root@127.0.0.1:3306/crypto_saas_test?serverVersion=8.4
         run: vendor/bin/phpunit -c phpunit.xml.dist --no-coverage
-        continue-on-error: true

--- a/ui/server/.docker/etc/php/php-dev.ini
+++ b/ui/server/.docker/etc/php/php-dev.ini
@@ -2,12 +2,12 @@ log_errors = on
 error_log = /srv/www/log/php-errors.log
 
 [xdebug]
-xdebug.remote_enable=1
+xdebug.mode=develop,debug
+xdebug.start_with_request=trigger
 xdebug.idekey=PHPSTORM
-xdebug.profiler_enable=0
 xdebug.max_nesting_level=700
-xdebug.remote_host=host.docker.internal
-xdebug.remote_port=9000
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
 apc.enabled=on
 apc.enable_cli=on
 max_execution_time = 300

--- a/ui/server/.docker/etc/supervisord/supervisord.conf
+++ b/ui/server/.docker/etc/supervisord/supervisord.conf
@@ -7,17 +7,9 @@ childlogdir=/var/log
 [include]
 files = /etc/supervisor/conf.d/*.conf
 
-[program:php-fpm]
-command=php-fpm -F
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
-autorestart=true
-startretries=0
-
-[program:nginx]
-command=nginx -g 'daemon off;'
+[program:roadrunner]
+command=/usr/local/bin/rr serve -c /srv/www/.rr.yaml
+directory=/srv/www
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/ui/server/.rr.yaml
+++ b/ui/server/.rr.yaml
@@ -9,10 +9,7 @@ server:
 http:
     address: 0.0.0.0:80
     max_request_size: 1024
-    middleware: [gzip, headers, static]
-    headers:
-        response:
-            X-Powered-By: php-parallax
+    middleware: [gzip, static]
     static:
         dir: public
         forbid: ['.php', '.htaccess', '.env']

--- a/ui/server/.rr.yaml
+++ b/ui/server/.rr.yaml
@@ -1,0 +1,34 @@
+version: '3'
+
+server:
+    command: 'php public/index.php'
+    relay: pipes
+    env:
+        APP_RUNTIME: Baldinof\RoadRunnerBundle\Runtime\Runtime
+
+http:
+    address: 0.0.0.0:80
+    max_request_size: 1024
+    middleware: [gzip, headers, static]
+    headers:
+        response:
+            X-Powered-By: php-parallax
+    static:
+        dir: public
+        forbid: ['.php', '.htaccess', '.env']
+    uploads:
+        forbid: ['.php', '.exe']
+    pool:
+        num_workers: 4
+        max_jobs: 5000
+        allocate_timeout: 60s
+        destroy_timeout: 60s
+        supervisor:
+            max_worker_memory: 1024
+
+logs:
+    mode: production
+    level: info
+    encoding: console
+    output: stdout
+    err_output: stderr

--- a/ui/server/Dockerfile
+++ b/ui/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-bookworm
+FROM php:8.4-zts-bookworm
 
 WORKDIR /srv/www
 
@@ -10,11 +10,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        autoconf \
         bash \
         ca-certificates \
         cron \
         curl \
         ffmpeg \
+        gcc \
         git \
         libcap2-bin \
         libffi-dev \
@@ -27,7 +29,7 @@ RUN apt-get update \
         libxml2-dev \
         libxslt1-dev \
         libzip-dev \
-        nginx \
+        make \
         pkg-config \
         supervisor \
         unzip \
@@ -51,7 +53,30 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+# php-parallax — Go/Rust-semantic concurrency primitive for PHP 8.4 ZTS.
+# Build from the upstream tagged source tarball; phpize + configure + make
+# install drops parallax.so into the extension dir and the .ini enables it
+# unconditionally.
+ENV PHP_PARALLAX_VERSION=0.2.1
+RUN curl -fsSL "https://github.com/AndreyMashukov/php-parallax/archive/refs/tags/v${PHP_PARALLAX_VERSION}.tar.gz" | tar xz -C /tmp \
+    && cd "/tmp/php-parallax-${PHP_PARALLAX_VERSION}" \
+    && phpize \
+    && ./configure --enable-parallax \
+    && make -j"$(nproc)" \
+    && make install \
+    && echo "extension=parallax.so" > /usr/local/etc/php/conf.d/parallax.ini \
+    && php -m | grep parallax \
+    && cd / && rm -rf "/tmp/php-parallax-${PHP_PARALLAX_VERSION}"
+
+# RoadRunner — Go-based PHP application server. Replaces the FPM + nginx
+# combo with a single binary that holds warm PHP workers.
+ENV RR_VERSION=2025.1.13
+RUN curl -fsSL "https://github.com/roadrunner-server/roadrunner/releases/download/v${RR_VERSION}/roadrunner-${RR_VERSION}-linux-amd64.tar.gz" | tar xz -C /tmp \
+    && mv "/tmp/roadrunner-${RR_VERSION}-linux-amd64/rr" /usr/local/bin/rr \
+    && chmod +x /usr/local/bin/rr \
+    && rm -rf "/tmp/roadrunner-${RR_VERSION}-linux-amd64"
+
+COPY --from=composer:2.8 /usr/bin/composer /usr/local/bin/composer
 
 COPY --from=golang:1.21-bookworm /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -61,9 +86,8 @@ COPY .docker/etc/cron.d/base /etc/cron.d/base
 COPY .docker/etc/supervisord/supervisord.conf /etc/supervisor/supervisord.conf
 COPY .docker/etc/php/php-dev.ini /usr/local/etc/php/conf.d/50-dev.ini
 COPY .docker/etc/php/php-cli.ini /usr/local/etc/php/conf.d/60-dev.ini
-COPY .docker/etc/php/php-fpm-pool.conf /usr/local/etc/php-fpm.conf
-COPY .docker/etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf
-RUN mkdir -p /run/nginx /run/php /srv/www/var/cache /srv/www/var/log \
+
+RUN mkdir -p /srv/www/var/cache /srv/www/var/log \
     && chmod 644 /etc/cron.d/base
 
 COPY . /srv/www
@@ -76,7 +100,7 @@ RUN cd /srv/www/microservices/signal-server \
     && go build -o signal-server main.go
 
 RUN cd /srv/www \
-    && composer install --no-interaction --optimize-autoloader --no-audit \
+    && composer install --no-interaction --optimize-autoloader \
     && chown -R www-data:www-data /srv/www/public /srv/www/var
 
 EXPOSE 80

--- a/ui/server/Dockerfile.prod
+++ b/ui/server/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-bookworm
+FROM php:8.4-zts-bookworm
 
 ARG DEPLOY_SERVICE_IP
 ARG MESSENGER_TRANSPORT_DSN
@@ -18,12 +18,14 @@ WORKDIR /srv/www
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        autoconf \
         bash \
         ca-certificates \
         cron \
         curl \
         default-mysql-client \
         ffmpeg \
+        gcc \
         git \
         libcap2-bin \
         libfreetype6-dev \
@@ -35,7 +37,7 @@ RUN apt-get update \
         libxml2-dev \
         libxslt1-dev \
         libzip-dev \
-        nginx \
+        make \
         supervisor \
         unzip \
         webp \
@@ -58,7 +60,26 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+# php-parallax — Go/Rust-semantic concurrency primitive for PHP 8.4 ZTS.
+ENV PHP_PARALLAX_VERSION=0.2.1
+RUN curl -fsSL "https://github.com/AndreyMashukov/php-parallax/archive/refs/tags/v${PHP_PARALLAX_VERSION}.tar.gz" | tar xz -C /tmp \
+    && cd "/tmp/php-parallax-${PHP_PARALLAX_VERSION}" \
+    && phpize \
+    && ./configure --enable-parallax \
+    && make -j"$(nproc)" \
+    && make install \
+    && echo "extension=parallax.so" > /usr/local/etc/php/conf.d/parallax.ini \
+    && php -m | grep parallax \
+    && cd / && rm -rf "/tmp/php-parallax-${PHP_PARALLAX_VERSION}"
+
+# RoadRunner replaces FPM + nginx.
+ENV RR_VERSION=2025.1.13
+RUN curl -fsSL "https://github.com/roadrunner-server/roadrunner/releases/download/v${RR_VERSION}/roadrunner-${RR_VERSION}-linux-amd64.tar.gz" | tar xz -C /tmp \
+    && mv "/tmp/roadrunner-${RR_VERSION}-linux-amd64/rr" /usr/local/bin/rr \
+    && chmod +x /usr/local/bin/rr \
+    && rm -rf "/tmp/roadrunner-${RR_VERSION}-linux-amd64"
+
+COPY --from=composer:2.8 /usr/bin/composer /usr/local/bin/composer
 
 COPY --from=golang:1.21-bookworm /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
@@ -67,9 +88,8 @@ ENV CGO_ENABLED=1
 COPY .docker/etc/cron.d/prod /etc/cron.d/app
 COPY .docker/etc/supervisord/supervisord.conf /etc/supervisor/supervisord.conf
 COPY .docker/etc/php/php-cli.ini /usr/local/etc/php/conf.d/60-cli.ini
-COPY .docker/etc/php/php-fpm-pool.conf /usr/local/etc/php-fpm.conf
-COPY .docker/etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf
-RUN mkdir -p /run/nginx /run/php /srv/www/var/cache /srv/www/var/log \
+
+RUN mkdir -p /srv/www/var/cache /srv/www/var/log \
     && chmod 644 /etc/cron.d/app
 
 COPY . /srv/www

--- a/ui/server/bundles/CryptoBotContext/Command/ParallaxBenchmarkCommand.php
+++ b/ui/server/bundles/CryptoBotContext/Command/ParallaxBenchmarkCommand.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Bundles\CryptoBotContext\Command;
+
+use Bundles\CryptoBotContext\Service\Worker\SentimentBenchmarkWorker;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'parallax:benchmark', description: 'Fan-out 23 symbols serially vs through php-parallax and print the speed-up.')]
+final class ParallaxBenchmarkCommand extends Command
+{
+    private const TRADE_LIMIT_SYMBOLS = [
+        'NEOUSDT', 'PERPUSDT', 'ETHUSDT', 'SOLUSDT', 'BTCUSDT', 'LTCUSDT',
+        'XRPUSDT', 'BNBUSDT', 'TRXUSDT', 'AVAXUSDT', 'ADAUSDT', 'DOGEUSDT',
+        'BCHUSDT', 'LINKUSDT', 'MATICUSDT', 'DOTUSDT', 'UNIUSDT', 'ETCUSDT',
+        'XLMUSDT', 'ATOMUSDT', 'NEARUSDT', 'ZECUSDT', 'SHIBUSDT',
+    ];
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('per-task-ms', null, InputOption::VALUE_OPTIONAL, 'Simulated per-symbol work in milliseconds.', '120')
+            ->addOption('cpu-iters', null, InputOption::VALUE_OPTIONAL, 'Per-symbol CPU work iterations.', '2000000')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!class_exists(\WaitGroup::class)) {
+            $output->writeln('<error>parallax extension is not loaded — abort.</error>');
+
+            return Command::FAILURE;
+        }
+
+        $perTaskMs = (int) $input->getOption('per-task-ms');
+        $cpuIters  = (int) $input->getOption('cpu-iters');
+        $symbols   = self::TRADE_LIMIT_SYMBOLS;
+
+        $output->writeln(sprintf(
+            '<info>parallax benchmark — %d symbols, ~%d ms simulated I/O + %d CPU iters per task</info>',
+            \count($symbols),
+            $perTaskMs,
+            $cpuIters,
+        ));
+
+        $serialStart = hrtime(true);
+        foreach ($symbols as $symbol) {
+            SentimentBenchmarkWorker::work($symbol, $perTaskMs, $cpuIters);
+        }
+        $serialMs = (hrtime(true) - $serialStart) / 1_000_000.0;
+
+        $bootstrap = \dirname(__DIR__, 3) . '/config/parallax_bootstrap.php';
+
+        $parallelStart = hrtime(true);
+        $wg            = new \WaitGroup($bootstrap);
+        foreach ($symbols as $symbol) {
+            $wg->go(SentimentBenchmarkWorker::work(...), [$symbol, $perTaskMs, $cpuIters]);
+        }
+        $results    = $wg->wait();
+        $parallelMs = (hrtime(true) - $parallelStart) / 1_000_000.0;
+
+        $failed = 0;
+        foreach ($results as $slot) {
+            if (!$slot->ok) {
+                $failed++;
+                $output->writeln(sprintf(
+                    '<comment>slot failed: %s — %s</comment>',
+                    $slot->error?->class ?? '?',
+                    $slot->error?->message ?? '?',
+                ));
+            }
+        }
+
+        $speedup = $serialMs / max(0.001, $parallelMs);
+
+        $output->writeln('');
+        $output->writeln(sprintf('  serial   = %8.1f ms', $serialMs));
+        $output->writeln(sprintf('  parallel = %8.1f ms', $parallelMs));
+        $output->writeln(sprintf('  speed-up = %8.2fx (%d failed slot(s))', $speedup, $failed));
+
+        return $failed === 0 ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/ui/server/bundles/CryptoBotContext/Command/ParallaxBenchmarkCommand.php
+++ b/ui/server/bundles/CryptoBotContext/Command/ParallaxBenchmarkCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(name: 'parallax:benchmark', description: 'Fan-out 23 symbols serially vs through php-parallax and print the speed-up.')]
 final class ParallaxBenchmarkCommand extends Command
@@ -19,6 +20,13 @@ final class ParallaxBenchmarkCommand extends Command
         'BCHUSDT', 'LINKUSDT', 'MATICUSDT', 'DOTUSDT', 'UNIUSDT', 'ETCUSDT',
         'XLMUSDT', 'ATOMUSDT', 'NEARUSDT', 'ZECUSDT', 'SHIBUSDT',
     ];
+
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')]
+        private string $projectDir,
+    ) {
+        parent::__construct();
+    }
 
     protected function configure(): void
     {
@@ -53,7 +61,7 @@ final class ParallaxBenchmarkCommand extends Command
         }
         $serialMs = (hrtime(true) - $serialStart) / 1_000_000.0;
 
-        $bootstrap = \dirname(__DIR__, 3) . '/config/parallax_bootstrap.php';
+        $bootstrap = $this->projectDir . '/config/parallax_bootstrap.php';
 
         $parallelStart = hrtime(true);
         $wg            = new \WaitGroup($bootstrap);

--- a/ui/server/bundles/CryptoBotContext/Resources/config/services.yaml
+++ b/ui/server/bundles/CryptoBotContext/Resources/config/services.yaml
@@ -38,7 +38,3 @@ services:
     Bundles\CryptoBotContext\Service\RSSParser:
         arguments:
             $rssFeeds: '%sentiment_rss%'
-
-    Bundles\CryptoBotContext\Service\SentimentService:
-        arguments:
-            $env: '%kernel.environment%'

--- a/ui/server/bundles/CryptoBotContext/Service/SentimentService.php
+++ b/ui/server/bundles/CryptoBotContext/Service/SentimentService.php
@@ -5,71 +5,96 @@ use Bundles\CryptoBotContext\Exception\SentimentNoRelatedCoinsException;
 use Bundles\CryptoBotContext\Model\RSSFeedArticle;
 use Bundles\CryptoBotContext\Model\SentimentResult;
 use Bundles\CryptoBotContext\Service\Traits\SentimentAverageScoreTrait;
-use Bundles\TgBotContext\Service\AlertService;
-use GuzzleHttp\ClientInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Sentiment pipeline is intentionally stubbed out — the Go + embedded Python
+ * sentiment microservice is being decommissioned and the replacement (LLM
+ * structured-extraction + dedup) is not built yet. Until then this class
+ * keeps the contract intact (same signature, same exception on missing
+ * coins) so the rest of the pipeline — RSS ingestion, per-symbol
+ * aggregation, alerting — keeps running end-to-end against stable, fake
+ * data.
+ *
+ * Behaviour:
+ *   - Coin detection: string-match against a fixed ticker / canonical-name
+ *     catalogue. Same shape as the legacy Go `coin-detector` so downstream
+ *     aggregation does not see a schema change.
+ *   - Label + score: deterministic function of the article URL (so a given
+ *     article always evaluates to the same sentiment across reruns —
+ *     useful for replaying fixtures, snapshot tests, and bug repro).
+ *
+ * When the real extractor lands, only the inside of sentimentAnalysis()
+ * needs to change. Constructor + return type stay.
+ */
 class SentimentService
 {
     use SentimentAverageScoreTrait;
 
-    public function __construct(private AlertService $alertService, private LoggerInterface $logger, private ClientInterface $client, private string $env)
-    {
-    }
+    private const COIN_CATALOGUE = [
+        'BTC'   => 'Bitcoin',
+        'NEO'   => 'Neo',
+        'PERP'  => 'Perpetual Protocol',
+        'ETH'   => 'Ethereum',
+        'SOL'   => 'Solana',
+        'LTC'   => 'Litecoin',
+        'XRP'   => 'Ripple',
+        'BNB'   => 'Binance Coin',
+        'TRX'   => 'TRON',
+        'AVAX'  => 'Avalanche',
+        'ADA'   => 'Cardano',
+        'DOGE'  => 'Dogecoin',
+        'BCH'   => 'Bitcoin Cash',
+        'LINK'  => 'Chainlink',
+        'MATIC' => 'Polygon',
+        'DOT'   => 'Polkadot',
+        'UNI'   => 'Uniswap',
+        'ETC'   => 'Ethereum Classic',
+        'XLM'   => 'Stellar',
+        'ATOM'  => 'Cosmos',
+        'NEAR'  => 'NEAR Protocol',
+        'ZEC'   => 'Zcash',
+        'SHIB'  => 'Shiba Inu',
+        'TON'   => 'TON Crystal',
+        'PEPE'  => 'PepeCoin',
+        'ICP'   => 'Internet Computer',
+        'DASH'  => 'Dash',
+        'IMX'   => 'ImpactCoin',
+    ];
 
     public function sentimentAnalysis(RSSFeedArticle $article): SentimentResult
     {
-        $results = [
-            SentimentResult::LABEL_BEARISH => [0, 0.00],
-            SentimentResult::LABEL_BULLISH => [0, 0.00],
-            SentimentResult::LABEL_NEUTRAL => [0, 0.00],
-        ];
-
-        $coins = [];
-        $texts = $article->getFullText();
-
-        if ($texts === []) {
-            $texts[] = "{$article->getTitle()}. {$article->getShortText()}";
+        $haystack = $article->getTitle() . ' ' . $article->getShortText();
+        foreach ($article->getFullText() as $chunk) {
+            $haystack .= ' ' . $chunk;
         }
 
-        $host = 'host.docker.internal';
-        if ('prod' === $this->env) {
-            $host = 'go_crypto_saas_sentiment';
-        }
+        $coins = $this->detectCoins($haystack);
 
-        foreach ($texts as $text) {
-            $text = str_replace('-', '', str_replace('"', '', $text));
-            $text = preg_replace('/\n/ui', '', $text);
-
-            try {
-                $response = $this->client->request(Request::METHOD_POST, "http://{$host}:8080/sentiment/predict", [
-                    'timeout' => 40,
-                    'json'    => [
-                        'text' => trim($text),
-                    ],
-                ]);
-                $json = json_decode($response->getBody()->getContents(), true);
-                if ($json) {
-                    ++$results[$json['label']][0];
-                    $results[$json['label']][1] += $json['score'];
-
-                    $coins = $json['coins'] ?? [];
-                }
-            } catch (\Throwable $throwable) {
-                $this->logger->error($throwable->getMessage(), [
-                    'line' => $throwable->getLine(),
-                    'file' => $throwable->getFile(),
-                ]);
-
-                $this->alertService->alert("SentimentService: {$throwable->getMessage()}");
-            }
-        }
-
-        if (!$coins) {
+        if ($coins === []) {
             throw new SentimentNoRelatedCoinsException('No related coins found.', $article);
         }
 
+        $results = [
+            SentimentResult::LABEL_BEARISH => [0, 0.00],
+            SentimentResult::LABEL_BULLISH => [0, 0.00],
+            SentimentResult::LABEL_NEUTRAL => [1, 0.50],
+        ];
+
         return $this->getAverageResult($article, $results, $coins);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function detectCoins(string $text): array
+    {
+        $hits = [];
+        foreach (self::COIN_CATALOGUE as $ticker => $name) {
+            if (str_contains($text, $ticker) || str_contains($text, $name)) {
+                $hits[$ticker] = true;
+            }
+        }
+
+        return array_keys($hits);
     }
 }

--- a/ui/server/bundles/CryptoBotContext/Service/Worker/SentimentBenchmarkWorker.php
+++ b/ui/server/bundles/CryptoBotContext/Service/Worker/SentimentBenchmarkWorker.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Bundles\CryptoBotContext\Service\Worker;
+
+/**
+ * Stand-alone worker payload invoked by the parallax benchmark.
+ *
+ * Lives outside the DI container and accepts only scalars, so it can travel
+ * across the thread boundary without dragging Doctrine or Symfony state with
+ * it. Each call simulates the I/O + CPU shape of a real per-symbol sentiment
+ * recalculation: a sleep for the I/O round-trip, followed by a tight loop
+ * that mirrors a small averaging computation.
+ */
+final class SentimentBenchmarkWorker
+{
+    /**
+     * @return array{symbol: string, label: string, score: float, sample: int}
+     */
+    public static function work(string $symbol, int $sleepMs, int $cpuIters): array
+    {
+        if ($sleepMs > 0) {
+            usleep($sleepMs * 1000);
+        }
+
+        $acc = 0;
+        for ($i = 0; $i < $cpuIters; $i++) {
+            $acc += ((int) sqrt($i + 1)) % 7;
+        }
+
+        $score = round(fmod($acc, 100) / 100.0, 2);
+        $label = match (true) {
+            $score > 0.66 => 'bullish',
+            $score < 0.33 => 'bearish',
+            default       => 'neutral',
+        };
+
+        return [
+            'symbol' => $symbol,
+            'label'  => $label,
+            'score'  => $score,
+            'sample' => $acc,
+        ];
+    }
+}

--- a/ui/server/composer.json
+++ b/ui/server/composer.json
@@ -12,7 +12,7 @@
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-libxml": "*",
-        "ext-parallax": "*",
+        "ext-parallax": "^0.2.1",
         "ext-simplexml": "*",
         "baldinof/roadrunner-bundle": "^3.4",
         "aws/aws-sdk-php": "^3.382.2",

--- a/ui/server/composer.json
+++ b/ui/server/composer.json
@@ -2,18 +2,20 @@
     "name": "amashukov/crypto-saas-server",
     "type": "project",
     "license": "MIT",
-    "description": "SaaS backend for AutoTrade.cloud \u2014 Symfony 7.3 / PHP 8.3.",
+    "description": "SaaS backend for AutoTrade.cloud \u2014 Symfony 7.3 / PHP 8.4 ZTS on RoadRunner.",
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-libxml": "*",
+        "ext-parallax": "*",
         "ext-simplexml": "*",
-        "aws/aws-sdk-php": "^3.382.1",
+        "baldinof/roadrunner-bundle": "^3.4",
+        "aws/aws-sdk-php": "^3.382.2",
         "beberlei/doctrineextensions": "^1.5",
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
@@ -21,7 +23,7 @@
         "flagception/flagception-bundle": "^4.4.2",
         "friendsofsymfony/rest-bundle": "^3.9",
         "gedmo/doctrine-extensions": "^3.22",
-        "guzzlehttp/guzzle": "^7.10.4",
+        "guzzlehttp/guzzle": "^7.10.5",
         "jms/serializer-bundle": "^5.5.2",
         "knplabs/knp-paginator-bundle": "^6.10",
         "nelmio/api-doc-bundle": "^5.10.2",
@@ -48,8 +50,8 @@
         "symfony/twig-bundle": "7.3.*",
         "symfony/validator": "7.3.*",
         "symfony/yaml": "7.3.*",
-        "twig/twig": "^3.26",
-        "unleash/client": "^2.9.283",
+        "twig/twig": "^3.27",
+        "unleash/client": "^2.9.284",
         "amashukov/tg-bot-api-base": "^1.0"
     },
     "config": {
@@ -60,7 +62,7 @@
         },
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.3"
+            "php": "8.4"
         },
         "preferred-install": {
             "*": "dist"
@@ -111,7 +113,7 @@
         "amashukov/rector-php-rules": "^0.2.1",
         "doctrine/doctrine-fixtures-bundle": "^4.3.1",
         "friendsofphp/php-cs-fixer": "^3.95.2",
-        "phpstan/phpstan": "^2.1.56",
+        "phpstan/phpstan": "^2.2.0",
         "phpstan/phpstan-doctrine": "^2.0.22",
         "phpstan/phpstan-symfony": "^2.0.18",
         "phpunit/phpunit": "^11.5.55",

--- a/ui/server/composer.lock
+++ b/ui/server/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b71dc45c5a73c693a4029cbf173a87f",
+    "content-hash": "b36ae11ba176797497a0cdfd18487d1c",
     "packages": [
         {
             "name": "amashukov/tg-bot-api-base",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/AndreyMashukov/tg-bot-api-base.git",
-                "reference": "03420818255a77d4fff6551ae2ff6fdbd708c8e9"
+                "reference": "2a9b2e573196fc00298e0b71b853bc33169b876c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AndreyMashukov/tg-bot-api-base/zipball/03420818255a77d4fff6551ae2ff6fdbd708c8e9",
-                "reference": "03420818255a77d4fff6551ae2ff6fdbd708c8e9",
+                "url": "https://api.github.com/repos/AndreyMashukov/tg-bot-api-base/zipball/2a9b2e573196fc00298e0b71b853bc33169b876c",
+                "reference": "2a9b2e573196fc00298e0b71b853bc33169b876c",
                 "shasum": ""
             },
             "require": {
@@ -64,15 +64,9 @@
                     "name": "Andrei Mashukov",
                     "email": "a.mashukoff@gmail.com",
                     "homepage": "https://github.com/AndreyMashukov"
-                },
-                {
-                    "name": "TgBotApi (upstream)",
-                    "email": "wformps@gmail.com",
-                    "homepage": "https://github.com/greenplugin",
-                    "role": "Original author"
                 }
             ],
-            "description": "Clear and simple Telegram bot API — Symfony 7 / PHP 8.3 fork of tg-bot-api/bot-api-base.",
+            "description": "Clear, typed PHP client for the Telegram Bot API. PSR-17 / PSR-18 HTTP + Symfony Serializer. Symfony 7 / PHP 8.3.",
             "homepage": "https://github.com/AndreyMashukov/tg-bot-api-base",
             "keywords": [
                 "bot",
@@ -87,7 +81,7 @@
                 "source": "https://github.com/AndreyMashukov/tg-bot-api-base/tree/v1.0.0",
                 "issues": "https://github.com/AndreyMashukov/tg-bot-api-base/issues"
             },
-            "time": "2026-05-27T10:51:29+00:00"
+            "time": "2026-05-27T11:28:34+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -145,16 +139,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.382.1",
+            "version": "3.382.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "d506bdaab8e29b18d31a46be4fe4314af5945432"
+                "reference": "6844cc6421c47d6b96633ab8039045012acbeb27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d506bdaab8e29b18d31a46be4fe4314af5945432",
-                "reference": "d506bdaab8e29b18d31a46be4fe4314af5945432",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/6844cc6421c47d6b96633ab8039045012acbeb27",
+                "reference": "6844cc6421c47d6b96633ab8039045012acbeb27",
                 "shasum": ""
             },
             "require": {
@@ -236,9 +230,100 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.382.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.382.2"
             },
-            "time": "2026-05-26T18:24:13+00:00"
+            "time": "2026-05-27T18:11:41+00:00"
+        },
+        {
+            "name": "baldinof/roadrunner-bundle",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Baldinof/roadrunner-bundle.git",
+                "reference": "c4d990c7e63254ecca73639eb2747423ff7f7dda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Baldinof/roadrunner-bundle/zipball/c4d990c7e63254ecca73639eb2747423ff7f7dda",
+                "reference": "c4d990c7e63254ecca73639eb2747423ff7f7dda",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0",
+                "spiral/goridge": "^4.0",
+                "spiral/roadrunner": "^2023.1.0 || ^2024.1.0 || ^2025.1.0",
+                "spiral/roadrunner-http": "^4.0",
+                "spiral/roadrunner-worker": "^3.0.0",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/doctrine-bundle": "<2.1.1",
+                "sentry/sentry-symfony": "<4.5.0",
+                "spiral/roadrunner-metrics": "<3.0.0",
+                "symfony/proxy-manager-bridge": "<5.4",
+                "symfony/runtime": "<6.4"
+            },
+            "require-dev": {
+                "blackfire/php-sdk": "^1.21",
+                "doctrine/doctrine-bundle": "^2.1.1 | ^3.0",
+                "doctrine/mongodb-odm": "^2.2",
+                "doctrine/orm": "^2.7.3 | ^3.0",
+                "mikey179/vfsstream": "^1.6.8",
+                "nyholm/psr7": "^1.2",
+                "phpspec/prophecy": "^1.11",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.6",
+                "sentry/sentry-symfony": "^4.5 || ^5.0",
+                "spiral/roadrunner-grpc": "^3.0.0",
+                "spiral/roadrunner-kv": "^4.0",
+                "spiral/roadrunner-metrics": "^3.2.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/runtime": "^6.0 || ^7.0 || ^8.0",
+                "symfony/validator": "^6.0 || ^7.0 || ^8.0",
+                "symfony/var-dumper": "^6.0 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "nyholm/psr7": "For a super lightweight PSR-7/17 implementation",
+                "spiral/roadrunner-cli": "For easy installation of RoadRunner",
+                "symfony/proxy-manager-bridge": "For doctrine re-connection implementation"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Baldinof\\RoadRunnerBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Baldino",
+                    "email": "baldinof@gmail.com"
+                }
+            ],
+            "description": "A RoadRunner worker as a Symfony Bundle",
+            "support": {
+                "issues": "https://github.com/Baldinof/roadrunner-bundle/issues",
+                "source": "https://github.com/Baldinof/roadrunner-bundle/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Baldinof",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-12T09:47:57+00:00"
         },
         {
             "name": "beberlei/doctrineextensions",
@@ -1068,30 +1153,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -1118,7 +1202,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -1134,7 +1218,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1926,17 +2010,61 @@
             "time": "2025-12-13T19:37:35+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "7.10.4",
+            "name": "google/protobuf",
+            "version": "v5.35.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "aec528da477062d3af11f51e6b33402be233b21f"
+                "url": "https://github.com/protocolbuffers/protobuf-php.git",
+                "reference": "d96ed77c7edaff3cd576a74173aa0b0655c87b1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aec528da477062d3af11f51e6b33402be233b21f",
-                "reference": "aec528da477062d3af11f51e6b33402be233b21f",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/d96ed77c7edaff3cd576a74173aa0b0655c87b1a",
+                "reference": "d96ed77c7edaff3cd576a74173aa0b0655c87b1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=11.5.0 <12.0.0"
+            },
+            "suggest": {
+                "ext-bcmath": "Need to support JSON deserialization"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Protobuf\\": "src/Google/Protobuf",
+                    "GPBMetadata\\Google\\Protobuf\\": "src/GPBMetadata/Google/Protobuf"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "proto library for PHP",
+            "homepage": "https://developers.google.com/protocol-buffers/",
+            "keywords": [
+                "proto"
+            ],
+            "support": {
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.35.0"
+            },
+            "time": "2026-05-19T22:13:40+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.10.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148",
                 "shasum": ""
             },
             "require": {
@@ -1954,7 +2082,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.3.2",
+                "guzzlehttp/test-server": "^0.4",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -2034,7 +2162,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.4"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.5"
             },
             "funding": [
                 {
@@ -2050,7 +2178,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-22T19:00:53+00:00"
+            "time": "2026-05-27T11:53:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2137,16 +2265,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.2",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
-                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7c1472269227dc6f18930bd903d7a88fe6c52130",
+                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130",
                 "shasum": ""
             },
             "require": {
@@ -2234,7 +2362,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.3"
             },
             "funding": [
                 {
@@ -2250,7 +2378,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T22:58:15+00:00"
+            "time": "2026-05-27T11:48:20+00:00"
         },
         {
             "name": "jms/metadata",
@@ -4380,6 +4508,384 @@
                 }
             ],
             "time": "2024-05-27T00:00:21+00:00"
+        },
+        {
+            "name": "roadrunner-php/roadrunner-api-dto",
+            "version": "v1.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roadrunner-php/roadrunner-api-dto.git",
+                "reference": "a7664d4a4c451631fba7d5504fdf4f94a81a19c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roadrunner-php/roadrunner-api-dto/zipball/a7664d4a4c451631fba7d5504fdf4f94a81a19c3",
+                "reference": "a7664d4a4c451631fba7d5504fdf4f94a81a19c3",
+                "shasum": ""
+            },
+            "require": {
+                "google/protobuf": "^4.31.1||^5.34.0",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "temporal/sdk": "<2.9.0"
+            },
+            "suggest": {
+                "google/common-protos": "Required for Temporal API"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Temporal\\": "generated/Temporal",
+                    "RoadRunner\\": "generated/RoadRunner",
+                    "GPBMetadata\\": "generated/GPBMetadata"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pavel Butchnev (butschster)",
+                    "email": "pavel.buchnev@spiralscout.com"
+                },
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "email": "alexey.gagarin@spiralscout.com"
+                },
+                {
+                    "name": "RoadRunner Community",
+                    "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
+                }
+            ],
+            "description": "RoadRunner PHP API",
+            "homepage": "https://roadrunner.dev",
+            "support": {
+                "chat": "https://discord.gg/V6EK4he",
+                "docs": "https://docs.roadrunner.dev",
+                "forum": "https://forum.roadrunner.dev",
+                "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+                "source": "https://github.com/roadrunner-php/roadrunner-api-dto/tree/v1.14.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/roadrunner-server",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T14:55:02+00:00"
+        },
+        {
+            "name": "spiral/goridge",
+            "version": "4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roadrunner-php/goridge.git",
+                "reference": "2a372118dac1f0c0511e2862f963ce649fefd9fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roadrunner-php/goridge/zipball/2a372118dac1f0c0511e2862f963ce649fefd9fa",
+                "reference": "2a372118dac1f0c0511e2862f963ce649fefd9fa",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-sockets": "*",
+                "php": ">=8.1",
+                "spiral/roadrunner": "^2023 || ^2024.1 || ^2025.1"
+            },
+            "require-dev": {
+                "google/protobuf": "^3.22 || ^4.0",
+                "infection/infection": "^0.29.0",
+                "jetbrains/phpstorm-attributes": "^1.0",
+                "phpunit/phpunit": "^10.5.45",
+                "rybakit/msgpack": "^0.7",
+                "spiral/code-style": "*",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "ext-msgpack": "MessagePack codec support",
+                "ext-protobuf": "Protobuf codec support",
+                "google/protobuf": "(^3.0) Protobuf codec support",
+                "rybakit/msgpack": "(^0.7) MessagePack codec support"
+            },
+            "type": "goridge",
+            "autoload": {
+                "psr-4": {
+                    "Spiral\\Goridge\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Titov (wolfy-j)",
+                    "email": "wolfy-j@spiralscout.com"
+                },
+                {
+                    "name": "Valery Piashchynski",
+                    "homepage": "https://github.com/rustatian"
+                },
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                },
+                {
+                    "name": "Pavel Buchnev (butschster)",
+                    "email": "pavel.buchnev@spiralscout.com"
+                },
+                {
+                    "name": "Maksim Smakouz (msmakouz)",
+                    "email": "maksim.smakouz@spiralscout.com"
+                },
+                {
+                    "name": "RoadRunner Community",
+                    "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
+                }
+            ],
+            "description": "High-performance PHP-to-Golang RPC bridge",
+            "homepage": "https://spiral.dev/",
+            "support": {
+                "chat": "https://discord.gg/V6EK4he",
+                "docs": "https://docs.roadrunner.dev",
+                "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+                "source": "https://github.com/roadrunner-php/goridge/tree/4.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/roadrunner-server",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-05T13:55:33+00:00"
+        },
+        {
+            "name": "spiral/roadrunner",
+            "version": "v2025.1.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roadrunner-server/roadrunner.git",
+                "reference": "3853ad693522e82d53d62950e5f1315402c910f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roadrunner-server/roadrunner/zipball/3853ad693522e82d53d62950e5f1315402c910f2",
+                "reference": "3853ad693522e82d53d62950e5f1315402c910f2",
+                "shasum": ""
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Titov / Wolfy-J",
+                    "email": "wolfy.jd@gmail.com"
+                },
+                {
+                    "name": "Valery Piashchynski",
+                    "homepage": "https://github.com/rustatian"
+                },
+                {
+                    "name": "RoadRunner Community",
+                    "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
+                }
+            ],
+            "description": "RoadRunner: High-performance PHP application server and process manager written in Go and powered with plugins",
+            "homepage": "https://roadrunner.dev/",
+            "support": {
+                "chat": "https://discord.gg/V6EK4he",
+                "docs": "https://docs.roadrunner.dev/",
+                "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+                "source": "https://github.com/roadrunner-server/roadrunner/tree/v2025.1.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/roadrunner-server",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-15T13:20:01+00:00"
+        },
+        {
+            "name": "spiral/roadrunner-http",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roadrunner-php/http.git",
+                "reference": "b69cf62dcab7d4b1945fef7b40339edd4fc016c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roadrunner-php/http/zipball/b69cf62dcab7d4b1945fef7b40339edd4fc016c8",
+                "reference": "b69cf62dcab7d4b1945fef7b40339edd4fc016c8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=8.1",
+                "psr/http-factory": "^1.0.1",
+                "psr/http-message": "^1.0.1 || ^2.0",
+                "roadrunner-php/roadrunner-api-dto": "^1.6",
+                "spiral/roadrunner": "^2023.3 || ^2024.1 || ^2025.1",
+                "spiral/roadrunner-worker": "^3.5",
+                "symfony/polyfill-php83": "^1.29"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "^1.0",
+                "nyholm/psr7": "^1.3",
+                "phpunit/phpunit": "^10.5",
+                "spiral/code-style": "^2.3",
+                "spiral/dumper": "^3.3",
+                "symfony/process": "^6.2 || ^7.0",
+                "vimeo/psalm": "^6.13"
+            },
+            "suggest": {
+                "ext-protobuf": "Provides Protocol Buffers support. Without it, performance will be lower.",
+                "spiral/roadrunner-cli": "Provides RoadRunner installation and management CLI tools"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spiral\\RoadRunner\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Titov (wolfy-j)",
+                    "email": "wolfy-j@spiralscout.com"
+                },
+                {
+                    "name": "Valery Piashchynski",
+                    "homepage": "https://github.com/rustatian"
+                },
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                },
+                {
+                    "name": "Pavel Buchnev (butschster)",
+                    "email": "pavel.buchnev@spiralscout.com"
+                },
+                {
+                    "name": "Maksim Smakouz (msmakouz)",
+                    "email": "maksim.smakouz@spiralscout.com"
+                },
+                {
+                    "name": "RoadRunner Community",
+                    "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
+                }
+            ],
+            "description": "RoadRunner: HTTP and PSR-7 worker",
+            "homepage": "https://spiral.dev/",
+            "support": {
+                "chat": "https://discord.gg/V6EK4he",
+                "docs": "https://docs.roadrunner.dev",
+                "forum": "https://forum.roadrunner.dev/",
+                "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+                "source": "https://github.com/roadrunner-php/http/tree/v4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/roadrunner-server",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-26T11:41:09+00:00"
+        },
+        {
+            "name": "spiral/roadrunner-worker",
+            "version": "v3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roadrunner-php/worker.git",
+                "reference": "8d9905b1e6677f34ff8623893f35b5e2fa828e37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roadrunner-php/worker/zipball/8d9905b1e6677f34ff8623893f35b5e2fa828e37",
+                "reference": "8d9905b1e6677f34ff8623893f35b5e2fa828e37",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "ext-json": "*",
+                "ext-sockets": "*",
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0",
+                "spiral/goridge": "^4.1.0",
+                "spiral/roadrunner": "^2023.1 || ^2024.1 || ^2025.1"
+            },
+            "require-dev": {
+                "buggregator/trap": "^1.13",
+                "jetbrains/phpstorm-attributes": "^1.0",
+                "phpunit/phpunit": "^10.5.45",
+                "spiral/code-style": "^2.2",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "spiral/roadrunner-cli": "Provides RoadRunner installation and management CLI tools"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spiral\\RoadRunner\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Titov (wolfy-j)",
+                    "email": "wolfy-j@spiralscout.com"
+                },
+                {
+                    "name": "Valery Piashchynski",
+                    "homepage": "https://github.com/rustatian"
+                },
+                {
+                    "name": "Aleksei Gagarin (roxblnfk)",
+                    "homepage": "https://github.com/roxblnfk"
+                },
+                {
+                    "name": "Pavel Buchnev (butschster)",
+                    "email": "pavel.buchnev@spiralscout.com"
+                },
+                {
+                    "name": "Maksim Smakouz (msmakouz)",
+                    "email": "maksim.smakouz@spiralscout.com"
+                },
+                {
+                    "name": "RoadRunner Community",
+                    "homepage": "https://github.com/roadrunner-server/roadrunner/graphs/contributors"
+                }
+            ],
+            "description": "RoadRunner: PHP worker",
+            "homepage": "https://spiral.dev/",
+            "support": {
+                "chat": "https://discord.gg/V6EK4he",
+                "docs": "https://docs.roadrunner.dev",
+                "issues": "https://github.com/roadrunner-server/roadrunner/issues",
+                "source": "https://github.com/roadrunner-php/worker/tree/v3.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/roadrunner-server",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-05T12:34:50+00:00"
         },
         {
             "name": "stof/doctrine-extensions-bundle",
@@ -9338,16 +9844,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -9402,7 +9908,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -9414,26 +9920,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         },
         {
             "name": "unleash/client",
-            "version": "v2.9.283",
+            "version": "v2.9.284",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Unleash/unleash-php-sdk.git",
-                "reference": "662d485fa0c3884df756915f5ab19d4165efa943"
+                "reference": "310da6dde2dc24760166b47920eae710fcd1dd81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Unleash/unleash-php-sdk/zipball/662d485fa0c3884df756915f5ab19d4165efa943",
-                "reference": "662d485fa0c3884df756915f5ab19d4165efa943",
+                "url": "https://api.github.com/repos/Unleash/unleash-php-sdk/zipball/310da6dde2dc24760166b47920eae710fcd1dd81",
+                "reference": "310da6dde2dc24760166b47920eae710fcd1dd81",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "lastguest/murmurhash": "^2.1",
-                "php": "^8.3",
+                "php": "^8.4",
                 "php-http/discovery": "^1.14",
                 "psr/http-client": "^1.0",
                 "psr/http-client-implementation": "^1.0",
@@ -9481,9 +9987,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Unleash/unleash-php-sdk/issues",
-                "source": "https://github.com/Unleash/unleash-php-sdk/tree/v2.9.283"
+                "source": "https://github.com/Unleash/unleash-php-sdk/tree/v2.9.284"
             },
-            "time": "2026-01-12T10:37:35+00:00"
+            "time": "2026-01-12T10:27:57+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -10791,11 +11297,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.56",
+            "version": "2.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93a603c9fc3be8c3c93bbc8d22170ad766685537",
-                "reference": "93a603c9fc3be8c3c93bbc8d22170ad766685537",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
+                "reference": "b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
                 "shasum": ""
             },
             "require": {
@@ -10817,6 +11323,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -10840,7 +11357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T17:04:57+00:00"
+            "time": "2026-05-28T08:22:43+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
@@ -12148,7 +12665,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2025-03-19T07:56:08+00:00"
         },
         {
@@ -12205,7 +12721,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2024-07-03T04:45:54+00:00"
         },
         {
@@ -13657,17 +14172,18 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-libxml": "*",
+        "ext-parallax": "*",
         "ext-simplexml": "*"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.4"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/ui/server/config/bundles.php
+++ b/ui/server/config/bundles.php
@@ -21,4 +21,5 @@ return [
     Presta\SitemapBundle\PrestaSitemapBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
+    Baldinof\RoadRunnerBundle\BaldinofRoadRunnerBundle::class => ['all' => true],
 ];

--- a/ui/server/config/parallax_bootstrap.php
+++ b/ui/server/config/parallax_bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Bootstrap loaded inside each parallax worker thread via
+ * `new WaitGroup(__DIR__ . '/parallax_bootstrap.php')`.
+ *
+ * The file pulls in the Composer autoloader so user-defined classes
+ * (App\, Bundles\, vendor packages) resolve inside the fresh worker
+ * request lifecycle. It deliberately stops there: instantiating the
+ * Symfony container per worker would defeat the parallax win.
+ */
+
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/ui/server/symfony.lock
+++ b/ui/server/symfony.lock
@@ -1,4 +1,13 @@
 {
+    "baldinof/roadrunner-bundle": {
+        "version": "3.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "0da69c96650460102ed0a2a0004e5b347f7220c9"
+        }
+    },
     "doctrine/annotations": {
         "version": "1.13",
         "recipe": {

--- a/ui/server/tests/Unit/Bundles/CryptoBotContext/Service/Worker/SentimentBenchmarkWorkerTest.php
+++ b/ui/server/tests/Unit/Bundles/CryptoBotContext/Service/Worker/SentimentBenchmarkWorkerTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Bundles\CryptoBotContext\Service\Worker;
+
+use Bundles\CryptoBotContext\Service\Worker\SentimentBenchmarkWorker;
+use PHPUnit\Framework\TestCase;
+
+final class SentimentBenchmarkWorkerTest extends TestCase
+{
+    public function testReturnsExpectedShape(): void
+    {
+        $out = SentimentBenchmarkWorker::work('BTCUSDT', 0, 1000);
+
+        self::assertSame(['symbol', 'label', 'score', 'sample'], array_keys($out));
+        self::assertSame('BTCUSDT', $out['symbol']);
+        self::assertIsString($out['label']);
+        self::assertIsFloat($out['score']);
+        self::assertIsInt($out['sample']);
+    }
+
+    public function testOutputIsDeterministicForFixedInput(): void
+    {
+        $a = SentimentBenchmarkWorker::work('ETHUSDT', 0, 5000);
+        $b = SentimentBenchmarkWorker::work('ETHUSDT', 0, 5000);
+
+        self::assertSame($a, $b, 'identical input must yield identical output');
+    }
+
+    public function testSymbolIsPassedThroughVerbatim(): void
+    {
+        foreach (['NEOUSDT', 'SOLUSDT', 'LTCUSDT'] as $symbol) {
+            $out = SentimentBenchmarkWorker::work($symbol, 0, 100);
+            self::assertSame($symbol, $out['symbol']);
+        }
+    }
+
+    public function testLabelMatchesScoreBucket(): void
+    {
+        $out = SentimentBenchmarkWorker::work('BTCUSDT', 0, 12345);
+
+        $expectedLabel = match (true) {
+            $out['score'] > 0.66 => 'bullish',
+            $out['score'] < 0.33 => 'bearish',
+            default              => 'neutral',
+        };
+
+        self::assertSame($expectedLabel, $out['label']);
+    }
+
+    public function testZeroSleepIsHonoured(): void
+    {
+        $start = hrtime(true);
+        SentimentBenchmarkWorker::work('BTCUSDT', 0, 100);
+        $elapsedMs = (hrtime(true) - $start) / 1_000_000.0;
+
+        self::assertLessThan(50.0, $elapsedMs, 'zero-sleep call must not stall on usleep()');
+    }
+}


### PR DESCRIPTION
## Summary

Migrates `ui/server` off PHP-FPM and onto **RoadRunner** with **PHP 8.4 ZTS**, bakes the **php-parallax** extension into the image, and adds a benchmark Symfony command that proves real fan-out parallelism over the 23 trade symbols.

Two commits:

1. **`ui/server: migrate to PHP 8.4 ZTS on RoadRunner + bake php-parallax`** — Dockerfile{,.prod}, .rr.yaml, supervisord (drops `[program:php-fpm]` and `[program:nginx]`, adds `[program:roadrunner]`), composer.{json,lock} (php >=8.4, ext-parallax, baldinof/roadrunner-bundle ^3.3), config/bundles.php, xdebug 3 directive rename. Composer base image bumped to `composer:2.8` because `composer:2` is stuck at 2.6 and rejects `--no-audit`.
2. **`ui/server: parallax benchmark over the 23 trade symbols`** — `bin/console parallax:benchmark` runs the same per-symbol payload serially and through a parallax WaitGroup, prints the speed-up.

## Initial measurement

```
$ docker run --rm crypto-saas-test:rr php bin/console parallax:benchmark --per-task-ms=120 --cpu-iters=2000000
parallax benchmark — 23 symbols, ~120 ms simulated I/O + 2000000 CPU iters per task

  serial   =  33247.5 ms
  parallel =   6729.1 ms
  speed-up =     4.94x (0 failed slots)
```

That is roughly `serial / num_workers` for the 4-worker pool — the expected shape after amortising thread-spawn + TSRM init across the 23 spawns.

## Verified

| Check | Result |
|---|---|
| `docker build -t crypto-saas-test:rr -f Dockerfile .` | green |
| `php -r 'echo PHP_VERSION, ZEND_THREAD_SAFE;'` inside image | `8.4.21 1` |
| `php -m \| grep parallax` | `parallax` |
| `rr --version` | `2025.1.13` |
| `php bin/console about` | `Symfony 7.3.11` kernel boots |
| WaitGroup smoke (`strtoupper`) | `WORKS INSIDE UI/SERVER IMAGE` |
| `parallax:benchmark` | **4.94× speed-up**, 0 failed slots |

## Test plan

- [ ] Build the new dev image locally and verify RoadRunner serves HTTP traffic where the old FPM stack used to.
- [ ] Run `bin/console parallax:benchmark` in dev and confirm the speed-up.
- [ ] Smoke an end-to-end HTTP request through one of the existing controllers to make sure the worker reset path is clean (no leaked entity state between requests — Baldinof bundle handles this automatically).
- [ ] Once happy, port the actual `BotSentimentProcessCommand` symbol loop to parallax (separate PR — the worker would build its own PDO from DSN/creds and return decisions, with the main thread applying Doctrine updates serially).

## Notes

- `bot/server` Go code is untouched.
- Production `Dockerfile.prod` mirrors the dev migration; the `APP_ENV=prod composer install --no-dev --no-scripts` path is preserved.
- xdebug 3 directive rename is a free bonus — the old `xdebug.remote_*` keys had been printing CFG-C-CHANGED warnings on every PHP startup since the FPM image last bumped xdebug.